### PR TITLE
fix: add missing 'Sabah' to supported region list

### DIFF
--- a/src/MalaysiaHoliday.php
+++ b/src/MalaysiaHoliday.php
@@ -38,6 +38,7 @@ class MalaysiaHoliday
         'Perlis',
         'Putrajaya',
         'Sarawak',
+        'Sabah', 
         'Selangor',
         'Terengganu'
     ];


### PR DESCRIPTION

Hi Hafiq Iqmal 👋🏻

This pull request fixes [Fatal error when filtering by state Sabah: Class "HttpException" not found](https://github.com/afiqiqmal/MalaysiaHoliday/issues/12), where the state **Sabah** was missing from the list of supported regions in the `MalaysiaHoliday` class.

### 🛠️ Changes made:
- Added `'Sabah'` to the `self::$region_array` in `MalaysiaHoliday.php`.

### 🐛 Root Cause:
The `checkRegional()` method validates the requested region against the `self::$region_array`. Since `'Sabah'` was not listed, any request involving `'Sabah'` resulted in a `RegionException`, causing the script to fail when attempting to fetch holidays for that region.

### ✅ Testing:
I verified the fix by running the following code:

```php
$holiday = new MalaysiaHoliday();
$data = $holiday->fromState('Sabah', 2025)->get();
```

This now successfully returns holiday data for **Sabah** in 2025 without throwing an exception.

Closes #12 
